### PR TITLE
Fix double curl bug

### DIFF
--- a/GoogleTranslate.php
+++ b/GoogleTranslate.php
@@ -89,6 +89,7 @@ class GoogleTranslate {
             curl_setopt($ch, CURLOPT_COOKIEJAR, $cookie);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             $output = curl_exec($ch);
+            return $output;
         }
         
         $queryString = http_build_query($params);


### PR DESCRIPTION
Fixed: call to makeCurl() was doing two sequential curl requests if no $cookieSet parameter was passed.
