### PR TITLE
(TCotten) Clean up temporary cookie jar files created by makeCurl()

### DIFF
--- a/GoogleTranslate.php
+++ b/GoogleTranslate.php
@@ -89,6 +89,11 @@ class GoogleTranslate {
             curl_setopt($ch, CURLOPT_COOKIEJAR, $cookie);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             $output = curl_exec($ch);
+
+            // Clean up temporary file
+            unset($ch);
+            unlink($cookie);
+
             return $output;
         }
         


### PR DESCRIPTION
- Previous version of the script left temporary files behind
- Avoids issues with the /tmp folder filling up with 65535 files and crashing other services such as MySQL

---

The makeCurl() function fails to clean up the temporary cookie jar files it creates in some environments.

This can cause errors in the /tmp folder where 65535 files block other services from using the folder, such as MySQL, leading to an Error 28.

I've made a pull request with a proposed fix.
