### PR TITLE
added new detection for single string response to fix #43

### DIFF
--- a/src/Stichoza/GoogleTranslate/Tokens/GoogleTokenGenerator.php
+++ b/src/Stichoza/GoogleTranslate/Tokens/GoogleTokenGenerator.php
@@ -68,7 +68,7 @@ class GoogleTokenGenerator implements TokenProviderInterface
         }
         $a = fmod($a, pow(10, 6));
 
-        return $a . '.' . ($a ^ $b);
+        return $a.'.'.($a ^ $b);
     }
 
     /**

--- a/src/Stichoza/GoogleTranslate/TranslateClient.php
+++ b/src/Stichoza/GoogleTranslate/TranslateClient.php
@@ -348,11 +348,11 @@ class TranslateClient
             return $carry;
         }
         // the response can be sometimes an translated string.
-        else if (is_string($responseArray)) {
+        elseif (is_string($responseArray)) {
             return $responseArray;
         } else {
             if (is_array($responseArray[0])) {
-                return array_reduce($responseArray[0], function($carry, $item) {
+                return array_reduce($responseArray[0], function ($carry, $item) {
                     $carry .= $item[0];
                     return $carry;
                 });

--- a/src/Stichoza/GoogleTranslate/TranslateClient.php
+++ b/src/Stichoza/GoogleTranslate/TranslateClient.php
@@ -308,11 +308,16 @@ class TranslateClient
 
         // Detect languages
         $detectedLanguages = [];
-        $responseArrayForLanguages = ($isArray) ? $responseArray[0] : [$responseArray];
-        foreach ($responseArrayForLanguages as $itemArray) {
-            foreach ($itemArray as $item) {
-                if (is_string($item)) {
-                    $detectedLanguages[] = $item;
+
+        // the response contains only single translation, dont create loop that will end with
+        // invalide foreach and warning
+        if ($isArray || !is_string($responseArray)) {
+            $responseArrayForLanguages = ($isArray) ? $responseArray[0] : [$responseArray];
+            foreach ($responseArrayForLanguages as $itemArray) {
+                foreach ($itemArray as $item) {
+                    if (is_string($item)) {
+                        $detectedLanguages[] = $item;
+                    }
                 }
             }
         }
@@ -341,6 +346,10 @@ class TranslateClient
             }
 
             return $carry;
+        }
+        // the response can be sometimes an translated string.
+        else if (is_string($responseArray)) {
+            return $responseArray;
         } else {
             if (is_array($responseArray[0])) {
                 return array_reduce($responseArray[0], function($carry, $item) {

--- a/src/Stichoza/GoogleTranslate/TranslateClient.php
+++ b/src/Stichoza/GoogleTranslate/TranslateClient.php
@@ -354,6 +354,7 @@ class TranslateClient
             if (is_array($responseArray[0])) {
                 return array_reduce($responseArray[0], function ($carry, $item) {
                     $carry .= $item[0];
+                    
                     return $carry;
                 });
             } else {


### PR DESCRIPTION
Continue fix for #43 

---

Still not working on latest version with this usage:
```
$translateClient = new TranslateClient();
$result = $translateClient->setSource($srcPrefix)->setTarget($fromPrefix)->translate($text);
```
API returns only translated text and the logic expects array. Added few detections to fix warnings and returned text. Tested on real application.