### PR TITLE
[+] Add PHPDoc tags about magic method calls

### DIFF
--- a/src/Stichoza/GoogleTranslate/TranslateClient.php
+++ b/src/Stichoza/GoogleTranslate/TranslateClient.php
@@ -21,6 +21,10 @@ use UnexpectedValueException;
  * @link        http://stichoza.com/
  *
  * @license     MIT
+ *
+ * @method string getLastDetectedSource() Can be called statically too.
+ * @method string translate(string $text) Can be called statically with signature
+ *                                        string translate(string $source, string $target, string $text)
  */
 class TranslateClient
 {


### PR DESCRIPTION
This helps with IDE autcompletion of instance methods. Cannot define instance and static methods with the same name using this tag, therefore I only left the instance methods, which I assume are more commonly used.