### PR TITLE
Add Known Limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ In addition, `translate()` and `trans()` methods will return `null` if there is 
  
  - `503 Service Unavailable` response:  
    If you are getting this error, it is most likely that Google has banned your external IP address and/or [requires you to solve a CAPTCHA](https://github.com/Stichoza/google-translate-php/issues/18). This is not a bug in this package. Google has become stricter, and it seems like they keep lowering the number of allowed requests per IP per a certain amount of time. Try sending less requests to stay under the radar, or change your IP frequently ([for example using proxies](#http-client-configuration)). Please note that once an IP is banned, even if it's only temporary, the ban can last from a few minutes to more than 12-24 hours, as each case is different.
+ - `429 Too Many Requests` response:
+   This error is basically the same as explained above.
  - `413 Request Entity Too Large` response:  
    This error means that your input string is too long. Google only allows a maximum of 5000 characters to be translated at once. If you want to translate a longer text, you can split it to shorter parts, and translate them one-by-one.
  


### PR DESCRIPTION
![Captura de tela de 2019-10-07 19-16-32](https://user-images.githubusercontent.com/11370172/66352889-179aba00-e937-11e9-8f55-a04914b993d5.png)

As can be seen on the image above, Google is returning an error `429 Too Many Requests` when receive too many request in a short time period. I can't say what's the limit, but it happened.