### PR TITLE
Php Return Value Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ In addition, `translate()` and `trans()` methods will return `null` if there is 
  - `413 Request Entity Too Large` response:
    This error means that your input string is too long. Google only allows a maximum of 5000 characters to be translated at once. If you want to translate a longer text, you can split it to shorter parts, and translate them one-by-one.
  - `403 Forbidden` response:
-   This is not an issue with this package. Google Translate itself has some problems when it comes to translating some characters. See https://github.com/Stichoza/google-translate-php/issues/119#issuecomment-558078133
+   This is not an issue with this package. Google Translate itself has some problems when it comes to translating some characters and HTML entities. See https://github.com/Stichoza/google-translate-php/issues/119#issuecomment-558078133
 
  
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -167,12 +167,15 @@ In addition, `translate()` and `trans()` methods will return `null` if there is 
 
 ## Known Limitations
  
- - `503 Service Unavailable` response:  
+ - `503 Service Unavailable` response:
    If you are getting this error, it is most likely that Google has banned your external IP address and/or [requires you to solve a CAPTCHA](https://github.com/Stichoza/google-translate-php/issues/18). This is not a bug in this package. Google has become stricter, and it seems like they keep lowering the number of allowed requests per IP per a certain amount of time. Try sending less requests to stay under the radar, or change your IP frequently ([for example using proxies](#http-client-configuration)). Please note that once an IP is banned, even if it's only temporary, the ban can last from a few minutes to more than 12-24 hours, as each case is different.
  - `429 Too Many Requests` response:
    This error is basically the same as explained above.
- - `413 Request Entity Too Large` response:  
+ - `413 Request Entity Too Large` response:
    This error means that your input string is too long. Google only allows a maximum of 5000 characters to be translated at once. If you want to translate a longer text, you can split it to shorter parts, and translate them one-by-one.
+ - `403 Forbidden` response:
+   This is not an issue with this package. Google Translate itself has some problems when it comes to translating some characters. See https://github.com/Stichoza/google-translate-php/issues/119#issuecomment-558078133
+
  
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Google Translate PHP
 ====================
 
-[![Build Status](https://travis-ci.org/Stichoza/google-translate-php.svg?branch=master)](https://travis-ci.org/Stichoza/google-translate-php) [![Latest Stable Version](https://img.shields.io/packagist/v/Stichoza/google-translate-php.svg)](https://packagist.org/packages/stichoza/google-translate-php) [![Total Downloads](https://img.shields.io/packagist/dt/Stichoza/google-translate-php.svg)](https://packagist.org/packages/stichoza/google-translate-php) [![Downloads Month](https://img.shields.io/packagist/dm/Stichoza/google-translate-php.svg)](https://packagist.org/packages/stichoza/google-translate-php) [![Petreon donation](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/stichoza)
+[![Build Status](https://travis-ci.org/Stichoza/google-translate-php.svg?branch=master)](https://travis-ci.org/Stichoza/google-translate-php) [![Latest Stable Version](https://img.shields.io/packagist/v/Stichoza/google-translate-php.svg)](https://packagist.org/packages/stichoza/google-translate-php) [![Total Downloads](https://img.shields.io/packagist/dt/Stichoza/google-translate-php.svg)](https://packagist.org/packages/stichoza/google-translate-php) [![Downloads Month](https://img.shields.io/packagist/dm/Stichoza/google-translate-php.svg)](https://packagist.org/packages/stichoza/google-translate-php) [![Petreon donation](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/stichoza) [![PayPal donation](https://img.shields.io/badge/paypal-donate-blue.svg)](https://paypal.me/stichoza)
 
 Free Google Translate API PHP Package. Translates totally free of charge.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ echo GoogleTranslate::trans('Hello again', 'ka', 'en');
 
 ### Language Detection
 
-To detect language automatically, just set the source language to `null`
+To detect language automatically, just set the source language to `null`:
 
 ```php
 $tr = new GoogleTranslate('es', null); // Or simply do not pass the second parameter 
@@ -58,9 +58,7 @@ $tr = new GoogleTranslate('es', null); // Or simply do not pass the second param
 $tr->setSource(); // Another way
 ```
 
-#### Get Detected Language
-
-You can also use `getLastDetectedSource()` to get detected language.
+Use `getLastDetectedSource()` to get detected language:
 
 ```php
 $tr = new GoogleTranslate('fr');
@@ -71,8 +69,6 @@ echo $tr->getLastDetectedSource(); // Output: en
 ```
 
 Return value will be `null` if the language couldn't be detected.
-
-#### Available languages
 
 Supported languages are listed in [Google API docs](https://cloud.google.com/translate/docs/languages).
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Free Google Translate API PHP Package. Translates totally free of charge.
 
 ---
 
- - [Installation](#installation)
- - [Basic Usage](#basic-usage)
+ - **[Installation](#installation)**
+ - **[Basic Usage](#basic-usage)**
  - [Advanced Usage](#advanced-usage)
    - [Language Detection](#language-detection)
    - [Using Raw Response](#using-raw-response)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ In addition, `translate()` and `trans()` methods will return `null` if there is 
  
  - `503 Service Unavailable` response:  
    If you are getting this error, it is most likely that Google has banned your external IP address and/or [requires you to solve a CAPTCHA](https://github.com/Stichoza/google-translate-php/issues/18). This is not a bug in this package. Google has become stricter, and it seems like they keep lowering the number of allowed requests per IP per a certain amount of time. Try sending less requests to stay under the radar, or change your IP frequently ([for example using proxies](#http-client-configuration)). Please note that once an IP is banned, even if it's only temporary, the ban can last from a few minutes to more than 12-24 hours, as each case is different.
+ - `429 Too Many Requests` response:
+   This error is basically the same as explained above.
  - `413 Request Entity Too Large` response:  
    This error means that your input string is too long. Google only allows a maximum of 5000 characters to be translated at once. If you want to translate a longer text, you can split it to shorter parts, and translate them one-by-one.
  

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ Google Translate PHP
 
 Free Google Translate API PHP Package. Translates totally free of charge.
 
+---
+
+ - [Installation](#installation)
+ - [Basic Usage](#basic-usage)
+ - [Advanced Usage](#advanced-usage)
+   - [Language Detection](#language-detection)
+   - [Using Raw Response](#using-raw-response)
+   - [Custom URL](#custom-url)
+   - [HTTP Client Configuration](#http-client-configuration)
+   - [Custom Token Generator](#custom-token-generator)
+   - [Errors and Exception Handling](#errors-and-exception-handling)
+ - [Known Limitations](#known-limitations)
+ - [Disclaimer](#disclaimer)
+ - [Donation](#donation)
+
 ## Installation
 
 Install this package via [Composer](https://getcomposer.org/).
@@ -150,7 +165,7 @@ Static method `trans()` and non-static `translate()` and `getResponse()` will th
 
 In addition, `translate()` and `trans()` methods will return `null` if there is no translation available.
 
-### Known Limitations
+## Known Limitations
  
  - `503 Service Unavailable` response:  
    If you are getting this error, it is most likely that Google has banned your external IP address and/or [requires you to solve a CAPTCHA](https://github.com/Stichoza/google-translate-php/issues/18). This is not a bug in this package. Google has become stricter, and it seems like they keep lowering the number of allowed requests per IP per a certain amount of time. Try sending less requests to stay under the radar, or change your IP frequently ([for example using proxies](#http-client-configuration)). Please note that once an IP is banned, even if it's only temporary, the ban can last from a few minutes to more than 12-24 hours, as each case is different.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Return value will be `null` if the language couldn't be detected.
 
 Supported languages are listed in [Google API docs](https://cloud.google.com/translate/docs/languages).
 
+### Using Raw Response
+
+For advanced usage, you might need the raw results that Google Translate provides. you can use `getResponse` method for that.
+
+```php
+$responseArray = $tr->getResponse('Hello world!');
+```
+
 ### Custom URL
 
 You can override the default Google Translate url by `setUrl` method. Useful for some countries
@@ -113,12 +121,28 @@ $tr->setOptions(['proxy' => 'socks5://localhost:1080'])->translate('World');
 
 For more information, see [Creating a Client](http://guzzle.readthedocs.org/en/latest/quickstart.html#creating-a-client) section in Guzzle docs (6.x version).
 
-### Using Raw Response
+### Custom Token Generator
 
-For advanced usage, you might need the raw results that Google Translate provides. you can use `getResponse` method for that.
+You can override the token generator class by passing a generator object as a fourth parameter of constructor or just use `setTokenProvider` method.
+
+Generator must implement `Stichoza\GoogleTranslate\Tokens\TokenProviderInterface`.
 
 ```php
-$responseArray = $tr->getResponse('Hello world!');
+use Stichoza\GoogleTranslate\Tokens\TokenProviderInterface;
+
+class MyTokenGenerator implements TokenProviderInterface
+{
+    public function generateToken(string $source, string $target, string $text) : string
+    {
+        // Your code here
+    }
+}
+```
+
+And use:
+
+```php
+$tr->setTokenProvider(new MyTokenGenerator);
 ```
 
 ### Errors and Exception Handling

--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -53,7 +53,7 @@ class GoogleTranslate
      * @var array URL Parameters
      */
     protected $urlParams = [
-        'client'   => 't',
+        'client'   => 'webapp',
         'hl'       => 'en',
         'dt'       => [
             't',   // Translate
@@ -293,20 +293,14 @@ class GoogleTranslate
             'sl'   => $this->source,
             'tl'   => $this->target,
             'tk'   => $this->tokenProvider->generateToken($this->source, $this->target, $string),
+            'q'    => $string
         ]);
 
         $queryUrl = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', http_build_query($queryArray));
 
-        $queryBodyArray = [
-            'q' => $string,
-        ];
-
-        $queryBodyEncoded = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', http_build_query($queryBodyArray));
-
         try {
-            $response = $this->client->post($this->url, [
+            $response = $this->client->get($this->url, [
                     'query' => $queryUrl,
-                    'body'  => $queryBodyEncoded,
                 ] + $this->options);
         } catch (RequestException $e) {
             throw new ErrorException($e->getMessage());

--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -220,6 +220,12 @@ class GoogleTranslate
      */
     public function translate(string $string) : string
     {
+        /*
+         * if source lang and target lang are the same
+         * just return the string without any request to google
+         */
+        if ($this->source == $this->target) return $string;
+        
         $responseArray = $this->getResponse($string);
 
         /*

--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -55,7 +55,18 @@ class GoogleTranslate
     protected $urlParams = [
         'client'   => 't',
         'hl'       => 'en',
-        'dt'       => 't',
+        'dt'       => [
+            't',   // Translate
+            'bd',  // Full translate with synonym ($bodyArray[1])
+            'at',  // Other translate ($bodyArray[5] - in google translate page this shows when click on translated word)
+            'ex',  // Example part ($bodyArray[13])
+            'ld',  // I don't know ($bodyArray[8])
+            'md',  // Definition part with example ($bodyArray[12])
+            'qca', // I don't know ($bodyArray[8])
+            'rw',  // Read also part ($bodyArray[14])
+            'rm',  // I don't know
+            'ss'   // Full synonym ($bodyArray[11])
+        ],
         'sl'       => null, // Source language
         'tl'       => null, // Target language
         'q'        => null, // String to translate


### PR DESCRIPTION
Version: 4.0.2
Php Version: 7.1

GoogleTranslate.php

```
public function translate(string $string) : string
{
      $responseArray = $this->getResponse($string);

        /*
         * if response in text and the content has zero the empty returns true, lets check
         * if response is string and not empty and create array for further logic
         */
        if (is_string($responseArray) && $responseArray != '') {
            $responseArray = [$responseArray];
        }

        // Check if translation exists
        if (!isset($responseArray[0]) || empty($responseArray[0])) {
            return null;
        }
        //....
}
```

This method can return a null value if translation not exists. So it should be like this:

`public function translate(string $string) : ?string`

