### PR TITLE
Don't proccess if langs are the same

### DIFF
--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -220,6 +220,12 @@ class GoogleTranslate
      */
     public function translate(string $string) : string
     {
+        /*
+         * if source lang and target lang are the same
+         * just return the string without any request to google
+         */
+        if ($this->source == $this->target) return $string;
+        
         $responseArray = $this->getResponse($string);
 
         /*


### PR DESCRIPTION
Returns string without proccessing if source and target languages are the same