### PR TITLE
feat: retrieve a list of supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Free Google Translate API PHP Package. Translates totally free of charge.
  - **[Basic Usage](#basic-usage)**
  - [Advanced Usage](#advanced-usage)
    - [Language Detection](#language-detection)
+   - [Supported Languages](#supported-languages)
    - [Preserving Parameters](#preserving-parameters)
    - [Using Raw Response](#using-raw-response)
    - [Custom URL](#custom-url)
@@ -92,7 +93,41 @@ echo $tr->getLastDetectedSource(); // Output: en
 
 Return value will be `null` if the language couldn't be detected.
 
-Supported languages are listed in [Google API docs](https://cloud.google.com/translate/docs/languages).
+### Supported Languages
+
+You can get a list of all the supported languages using the `languages` method.
+
+```php
+$tr = new GoogleTranslate();
+
+$languages = $tr->languages(); // Get supported languages in iso-639 format
+
+// Output: [ 'ab', 'ace', 'ach', 'aa', 'af', 'sq', 'alz', ... ]
+```
+
+Optionally, pass a target language code to retrieve supported languages with names displayed in that language.
+
+```php
+$tr = new GoogleTranslate();
+
+$languages = $tr->languages('en'); // Get supported languages, display name in english
+// Output: [ 'en' => English', 'es' => 'Spanish', 'it' => 'Italian', ... ]
+
+echo $languages['en']; // Output: 'English'
+echo $languages['ka']; // Output: 'Georgian'
+```
+
+Same as with the `translate`/`trans` methods, you can also use a static `langs` method:
+
+```php
+GoogleTranslate::langs();
+// Output: [ 'ab', 'ace', 'ach', 'aa', 'af', 'sq', 'alz', ... ]
+
+GoogleTranslate::langs('en');
+// Output: [ 'en' => English', 'es' => 'Spanish', 'it' => 'Italian', ... ]
+```
+
+Supported languages are also listed in [Google API docs](https://cloud.google.com/translate/docs/languages).
 
 ### Preserving Parameters
 
@@ -241,4 +276,3 @@ If this package helped you reduce your time to develop something, or it solved a
 
  - [Patreon](https://www.patreon.com/stichoza)
  - [PayPal](https://paypal.me/stichoza)
-

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": "^8.0",
         "guzzlehttp/guzzle": "^7.0",
+        "ext-dom": "*",
         "ext-json": "*",
         "ext-mbstring": "*"
     },

--- a/src/Exceptions/LanguagesRequestException.php
+++ b/src/Exceptions/LanguagesRequestException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stichoza\GoogleTranslate\Exceptions;
+
+use ErrorException;
+
+class LanguagesRequestException extends ErrorException
+{
+    //
+}

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -4,6 +4,7 @@ namespace Stichoza\GoogleTranslate\Tests;
 
 use ErrorException;
 use PHPUnit\Framework\TestCase;
+use Stichoza\GoogleTranslate\Exceptions\LanguagesRequestException;
 use Stichoza\GoogleTranslate\Exceptions\LargeTextException;
 use Stichoza\GoogleTranslate\Exceptions\RateLimitException;
 use Stichoza\GoogleTranslate\Exceptions\TranslationDecodingException;
@@ -67,5 +68,12 @@ class ExceptionTest extends TestCase
         $this->expectException(ErrorException::class);
 
         $this->tr->setUrl('https://httpstat.us/413')->translate('Test');
+    }
+
+    public function testLanguagesRequestException(): void
+    {
+        $this->expectException(LanguagesRequestException::class);
+
+        $this->tr->setUrl('https://httpstat.us/418')->languages();
     }
 }

--- a/tests/SupportedLanguagesTest.php
+++ b/tests/SupportedLanguagesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Stichoza\GoogleTranslate\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Stichoza\GoogleTranslate\GoogleTranslate;
+
+class SupportedLanguagesTest extends TestCase
+{
+    public GoogleTranslate $tr;
+
+    public function setUp(): void
+    {
+        $this->tr = new GoogleTranslate();
+    }
+
+    public function testLanguageCodesRequest(): void
+    {
+        $result = $this->tr->languages();
+        $this->assertContains('en', $result);
+        $this->assertContains('fr', $result);
+        $this->assertContains('ka', $result);
+        $this->assertContains('it', $result);
+        $this->assertContains('pt', $result);
+        $this->assertContains('pt-PT', $result);
+        $this->assertContains('pl', $result);
+        $this->assertContains('vi', $result);
+        $this->assertContains('ja', $result);
+        $this->assertContains('et', $result);
+        $this->assertContains('hr', $result);
+        $this->assertContains('es', $result);
+        $this->assertContains('zh-CN', $result);
+        $this->assertContains('zh-TW', $result);
+    }
+
+    public function testLocalizedLanguages(): void
+    {
+        $result = $this->tr->languages('en');
+        $this->assertEquals('English', $result['en']);
+        $this->assertEquals('French', $result['fr']);
+        $this->assertEquals('Georgian', $result['ka']);
+        $this->assertEquals('Italian', $result['it']);
+        $this->assertEquals('Portuguese (Brazil)', $result['pt']);
+
+        $result = $this->tr->languages('ka');
+        $this->assertEquals('ინგლისური', $result['en']);
+        $this->assertEquals('ფრანგული', $result['fr']);
+        $this->assertEquals('ქართული', $result['ka']);
+        $this->assertEquals('იტალიური', $result['it']);
+        $this->assertEquals('პორტუგალიური (ბრაზილია)', $result['pt']);
+
+        $result = $this->tr->languages('pt');
+        $this->assertEquals('Inglês', $result['en']);
+        $this->assertEquals('Francês', $result['fr']);
+        $this->assertEquals('Georgiano', $result['ka']);
+        $this->assertEquals('Italiano', $result['it']);
+        $this->assertEquals('Português (Brasil)', $result['pt']);
+    }
+
+    public function testLanguagesEquality(): void
+    {
+        $resultOne = GoogleTranslate::langs();
+        $resultTwo = $this->tr->languages();
+
+        $this->assertEqualsIgnoringCase($resultOne, $resultTwo, 'Static and instance methods should return same result.');
+
+        $resultOne = GoogleTranslate::langs('pt');
+        $resultTwo = $this->tr->languages('pt');
+
+        $this->assertEqualsIgnoringCase($resultOne, $resultTwo, 'Static and instance methods should return same result.');
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds languages methods to let the package user retrieve a complete list of supported languages on Google Translate. It's implemented in the new `languages`, `localizedLanguages` and static `langs` methods, added tests for full coverage and updated the README accordingly.

## Details

### Why
I've noticed that it's common feature of the paid translation apis (google, amazon, deelp, bing/azure) so adding it here for parity seemed like a good idea. I also use this package as one of my api drivers while locally testing my translation tools, so bringing it inline with the other drivers benefits me personally. 

Feel free to change or even dismiss this PR if you find it's not needed. 

### Implementation

There are 2 options for users to retrieve the languages:

`localizedLanguages($target)` lets users pull a list iso codes mapped to the name of the language displayed in the `$target` language.

```
(new GoogleTranslate)->localizedLanguages('en');
(new GoogleTranslate)->languages('en');
GoogleTranslate::langs('en');

// Output
[
    ...
    'en' => English', 
    'es' => 'Spanish', 
    'it' => 'Italian', 
    ...
]
```

While, `languages` & the static `langs` still let you pass in a `$target` display language for the same result OR let you skip it and return only the list of iso-639 language codes.

```
(new GoogleTranslate)->languages();

GoogleTranslate::langs()

// Output
[ 'ab', 'ace', 'ach', 'aa', 'af', 'sq', 'alz', ... ]
```

All of this works by crawling the mobile translate site with the language menu open, https://translate.google.com/m?mui=sl. I've opted to use the built-in php `ext-dom` with its `DOMDocument` and `DOMXPath` but another option could be the `symfony/dow-crawler` package. `ext-dom` seems like a pretty standard extension that is often bundled with php without the need to install anything with pecl or composer.

## Testing

- full coverage added in `tests/SupportedLanguagesTest.php`
- readme contains usage details and example outputs.