### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,13 +20,14 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         dependency-versions:
           - "lowest"
           - "highest"
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -35,9 +36,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v2
-        with:
-          dependency-versions: ${{ matrix.dependency-versions }}
+        run: composer install --prefer-dist --no-progress
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/.idea/
 /vendor/
 composer.lock
+.phpunit.result.cache

--- a/src/GoogleTranslate.php
+++ b/src/GoogleTranslate.php
@@ -117,7 +117,13 @@ class GoogleTranslate
      * @param TokenProviderInterface|null $tokenProvider
      * @param bool|string $preserveParameters Boolean or custom regex pattern to match parameters
      */
-    public function __construct(string $target = 'en', string $source = null, array $options = [], TokenProviderInterface $tokenProvider = null, bool|string $preserveParameters = false)
+    public function __construct(
+        string                  $target = 'en',
+        ?string                 $source = null,
+        array                   $options = [],
+        ?TokenProviderInterface $tokenProvider = null,
+        bool|string             $preserveParameters = false
+    )
     {
         $this->client = new Client();
         $this->setTokenProvider($tokenProvider ?? new GoogleTokenGenerator)
@@ -145,7 +151,7 @@ class GoogleTranslate
      * @param string|null $source Source language code (null for automatic language detection)
      * @return GoogleTranslate
      */
-    public function setSource(string $source = null): self
+    public function setSource(?string $source = null): self
     {
         $this->source = $source ?? 'auto';
         return $this;
@@ -224,7 +230,14 @@ class GoogleTranslate
      * @throws TranslationRequestException If any other HTTP related error occurs
      * @throws TranslationDecodingException If response JSON cannot be decoded
      */
-    public static function trans(string $string, string $target = 'en', string $source = null, array $options = [], TokenProviderInterface $tokenProvider = null, bool|string $preserveParameters = false): ?string
+    public static function trans(
+        string                  $string,
+        string                  $target = 'en',
+        ?string                 $source = null,
+        array                   $options = [],
+        ?TokenProviderInterface $tokenProvider = null,
+        bool|string             $preserveParameters = false
+    ): ?string
     {
         return (new self)
             ->setTokenProvider($tokenProvider ?? new GoogleTokenGenerator)

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -14,6 +14,8 @@ class UtilityTest extends TestCase
 
     public ReflectionMethod $method;
 
+    private ReflectionClass $reflection;
+
     public function setUp(): void
     {
         $this->tr = new GoogleTranslate();


### PR DESCRIPTION
Various Fixes and PHP 8.4 compatibility

1. resolve deprecation warning for dynamic property creation
2. fix deprecation by changing implicit null to explicit null
3. update CI workflow to include PHP 8.4 and refactor as well
4. updated `.gitignore` to ignore additional file and directory