### PR TITLE
feat: deprecate PHP 8.0 EOL and allow 8.1 to 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1|^8.2|^8.3|^8.4",
         "guzzlehttp/guzzle": "^7.0",
         "ext-dom": "*",
         "ext-json": "*",


### PR DESCRIPTION
Deprecate PHP 8.0 EOL and allow PHP versions from 8.1 to 8.4