### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^7.0 || ^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-mbstring": "*"


### PR DESCRIPTION
## Summary

- Allow `guzzlehttp/guzzle` `^8.0` alongside `^7.0` so consumers can upgrade their HTTP client stack without a fork or constraint conflict.
- No runtime API changes; this is a Composer constraint-only update.

## Context

Guzzle 8 is available and some projects (including ours) are moving to it. The package currently requires `^7.0` only, which blocks that upgrade path even though the library usage of Guzzle remains compatible.

## Changes

- `composer.json`: `guzzlehttp/guzzle` → `^7.0 || ^8.0`

## Test plan

- [ ] Install with Guzzle 7 (`composer update guzzlehttp/guzzle:^7.0`) and run the test suite
- [ ] Install with Guzzle 8 (`composer update guzzlehttp/guzzle:^8.0`) and run the test suite
- [ ] Smoke a simple `GoogleTranslate::trans(...)` / instance `translate()` call under both major versions